### PR TITLE
[fix] test 뻑나는 것들 수정 #111

### DIFF
--- a/src/domain/direct-message-room/direct-message-room.service.spec.ts
+++ b/src/domain/direct-message-room/direct-message-room.service.spec.ts
@@ -86,7 +86,7 @@ describe('DmLogService', () => {
         expect(directMessageRooms).toHaveProperty('chatList');
         expect(directMessageRooms.chatList[0]).toHaveProperty('nickname');
         expect(directMessageRooms.chatList[0]).toHaveProperty('imgUrl');
-        expect(directMessageRooms.chatList[0]).toHaveProperty('newChat');
+        expect(directMessageRooms.chatList[0]).toHaveProperty('newChats');
       });
 
       it('[Valid Case] 현재 진행중인 DM목록 반환', async () => {

--- a/src/domain/direct-message/direct-message.service.spec.ts
+++ b/src/domain/direct-message/direct-message.service.spec.ts
@@ -17,6 +17,7 @@ import { GetDirectMessageHistoryResponseDto } from './dto/get.direct-message.his
 import { DirectMessageRoomModule } from '../direct-message-room/direct-message-room.module';
 import { DirectMessageRoom } from '../direct-message-room/direct-message-room.entity';
 import { CHATTYPE_ME, CHATTYPE_OTHERS } from 'src/global/type/type.chat';
+import { BadRequestException } from '@nestjs/common';
 
 describe('DmLogService', () => {
   let service: DirectMessageService;
@@ -321,15 +322,9 @@ describe('DmLogService', () => {
           message: '안가야하는log0',
         };
 
-        await service.postDirectMessage(userDirectMessegeDto);
-
-        const dmLog: DirectMessage[] = await dmlogRepository.find({
-          where: {
-            sender: { id: testData.users[0].id },
-          },
-        });
-
-        expect(dmLog.length).toBe(0);
+        await expect(
+          service.postDirectMessage(userDirectMessegeDto),
+        ).rejects.toThrow(new BadRequestException('not a friend'));
       });
     });
   });

--- a/src/domain/friend/controller/friend.relation.controller.spec.ts
+++ b/src/domain/friend/controller/friend.relation.controller.spec.ts
@@ -73,7 +73,9 @@ describe('FriendController - Relation', () => {
 
     describe('/users/friends/pendings', () => {
       it('친구 요청 목록 조회', async () => {
-        await friendTestService.createUserRequesting(50);
+        for (let i = 1; i < 50; i++) {
+          await friendTestService.createUser0ToBeRequested(i);
+        }
         const user = friendTestService.users[0];
         const token = await friendTestService.giveTokenToUser(user);
         const response = await req(token, 'GET', `/users/friends/pendings`);
@@ -143,7 +145,7 @@ describe('FriendController - Relation', () => {
       it('친구 요청 수락 성공', async () => {
         const user = friendTestService.users[0];
         const sender = friendTestService.users[1];
-        await friendTestService.createUser0ToRequesting(sender.id);
+        await friendTestService.createUser0ToBeRequested(sender.id);
         const token = await friendTestService.giveTokenToUser(user);
         const response = await req(
           token,
@@ -155,7 +157,7 @@ describe('FriendController - Relation', () => {
       it('친구 요청 수락 씹기(이미 친구)', async () => {
         const user = friendTestService.users[0];
         const alreadyFriend = friendTestService.users[1];
-        await friendTestService.createUser0ToRequesting(alreadyFriend.id);
+        await friendTestService.createUser0ToBeRequested(alreadyFriend.id);
         await friendTestService.createUser0ToFriends(alreadyFriend.id);
         const token = await friendTestService.giveTokenToUser(user);
         const response = await req(
@@ -191,7 +193,7 @@ describe('FriendController - Relation', () => {
       it('친구 요청 거절 성공', async () => {
         const user = friendTestService.users[0];
         const sender = friendTestService.users[1];
-        await friendTestService.createUser0ToRequesting(sender.id);
+        await friendTestService.createUser0ToBeRequested(sender.id);
         const token = await friendTestService.giveTokenToUser(user);
         const response = await req(
           token,

--- a/src/domain/friend/friend.service.spec.ts
+++ b/src/domain/friend/friend.service.spec.ts
@@ -201,7 +201,8 @@ describe('FriendService', () => {
       });
 
       it('[Valid Case] 친구요청 목록이 정상적으로 반환 되는지 확인', async () => {
-        await testData.createUserRequesting(10);
+        await testData.createUser0ToBeRequested(1);
+        await testData.createUser0ToBeRequested(2);
 
         const getUserPendingDto: GetUserPendingFriendDto = {
           userId: testData.users[0].id,
@@ -212,8 +213,8 @@ describe('FriendService', () => {
 
         const friendRequest: Friend = await friendRepository.findOne({
           where: {
-            sender: { id: testData.users[0].id },
-            receiver: { id: testData.users[1].id },
+            sender: { id: testData.users[1].id },
+            receiver: { id: testData.users[0].id },
             status: Not(FRIENDSTATUS_DELETED),
           },
         });
@@ -236,9 +237,11 @@ describe('FriendService', () => {
       });
 
       it('[Valid Case] 친구요청 목록이 알파벳순서로 정렬되는지 확인', async () => {
-        await testData.createUserRequesting(10);
-        await testData.createUser0ToRequesting(14); // 친구 테이블 1에 있어야해요
-        await testData.createUser0ToRequesting(15); //친구 테이블 2에 있어야해요
+        for (let i = 1; i < 10; i++) {
+          await testData.createUser0ToBeRequested(i);
+        }
+        await testData.createUser0ToBeRequested(14); // 친구 테이블 1에 있어야해요
+        await testData.createUser0ToBeRequested(15); //친구 테이블 2에 있어야해요
 
         const getUserPendingDto: GetUserPendingFriendDto = {
           userId: testData.users[0].id,
@@ -290,7 +293,7 @@ describe('FriendService', () => {
 
       it('[Valid Case] 양쪽에서 친구 요청 보낸경우', async () => {
         await testData.createUserRequesting(10);
-        await testData.createUser0ToRequesting(1);
+        await testData.createUser0ToBeRequested(1);
 
         const userFriendsAcceptDto: PostUserFriendAcceptDto = {
           userId: testData.users[0].id,
@@ -434,7 +437,9 @@ describe('FriendService', () => {
       });
 
       it('[Valid Case]친구요청이 있는경우', async () => {
-        await testData.createUserRequesting(10);
+        for (let i = 1; i < 10; i++) {
+          await testData.createUser0ToBeRequested(i);
+        }
 
         const userFriendNotificationDto: GetUserFriendNotificationsRequestDto =
           {
@@ -450,7 +455,9 @@ describe('FriendService', () => {
       });
 
       it('[Valid Case]  50개 까지만 요청 받기', async () => {
-        await testData.createUserRequesting(60);
+        for (let i = 1; i < 100; i++) {
+          await testData.createUser0ToBeRequested(i);
+        }
 
         const userFriendNotificationDto: GetUserFriendNotificationsRequestDto =
           {

--- a/src/domain/friend/friend.service.ts
+++ b/src/domain/friend/friend.service.ts
@@ -81,11 +81,8 @@ export class FriendService {
       await this.friendRepository.findFriendRequestingsByUserId(myId);
 
     const friends: FriendDto[] = userFriends.map((friend) => {
-      const { sender, receiver } = friend;
-      if (friend.receiver.id === myId) {
-        return FriendDto.fromUser(sender);
-      }
-      return FriendDto.fromUser(receiver);
+      const { sender } = friend;
+      return FriendDto.fromUser(sender);
     });
 
     friends.sort(this.compareNicknames);

--- a/src/domain/friend/test/friend.test.service.ts
+++ b/src/domain/friend/test/friend.test.service.ts
@@ -83,7 +83,7 @@ export class FriendTestService {
     }
   }
 
-  async createUser0ToRequesting(person: number): Promise<void> {
+  async createUser0ToBeRequested(person: number): Promise<void> {
     const index: number = person;
     const roomId = FriendChatManager.generateRoomId(
       this.users[index].id.toString(),


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #111
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
대체로 친구 요청 확인 로직이 유저가 sender/receiver 두 경우 다 확인하는 데에서 receiver인 경우만 확인 하는 것으로 바뀌면서
관련된 온갖 테스트가 유저가 sender이기만 한 경우로 만들어져서 뻑이 났습니다..
테스트 제대로 안돌려보고 올려서 죄송합니다. ㅠㅠ 변명하자면 머지컨플릭트 무서워서 그랬는데 잘할게용

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- newChat -> newChats로 통일
- 친구 아닌 이에게 dm전송시 400 에러
