### PR TITLE
[Feat] 일반 유저용 channel controller 작성 #116

### DIFF
--- a/src/domain/channel/channel.chats.response.dto.ts
+++ b/src/domain/channel/channel.chats.response.dto.ts
@@ -1,0 +1,6 @@
+import { ChannelMessageHistoryDto } from './dto/channel-message.history.dto';
+
+export class ChannelChatsResponseDto {
+  chats: ChannelMessageHistoryDto[];
+  isLastPage: boolean;
+}

--- a/src/domain/channel/channel.me.response.dto.ts
+++ b/src/domain/channel/channel.me.response.dto.ts
@@ -1,0 +1,5 @@
+import { ChannelMeDto } from './dto/channel.me.dto';
+
+export class ChannelMeResponseDto {
+  myChannel: ChannelMeDto;
+}

--- a/src/domain/channel/channel.module.ts
+++ b/src/domain/channel/channel.module.ts
@@ -10,11 +10,14 @@ import { ChannelUserRepository } from './repository/channel-user.repository';
 import { ChannelMessageRepository } from './repository/channel-message.repository';
 import { ChannelNormalService } from './service/channel.normal.service';
 import { Channel } from './entity/channel.entity';
+import { ChannelNormalController } from './channel.normal.controller';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
     FactoryModule,
     GatewayModule,
+    UserModule,
     TypeOrmModule.forFeature([Channel, ChannelUser, ChannelMessage]),
   ],
   providers: [
@@ -24,6 +27,7 @@ import { Channel } from './entity/channel.entity';
     ChannelUserRepository,
     ChannelMessageRepository,
   ],
+  controllers: [ChannelNormalController],
   exports: [ChannelAdminService, ChannelNormalService],
 })
 export class ChannelModule {}

--- a/src/domain/channel/channel.normal.controller.ts
+++ b/src/domain/channel/channel.normal.controller.ts
@@ -1,0 +1,305 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ChannelNormalService } from './service/channel.normal.service';
+import { OrderChannelType } from './type/type.order.channel';
+import { ChannelPageResponseDto } from './dto/channel.page.response.dto';
+import { Requestor } from '../auth/jwt/auth.requestor.decorator';
+import { UserIdCardDto } from '../auth/jwt/auth.user.id-card.dto';
+import { ChannelParticipantsResponseDto } from './dto/channel.participant.request.dto';
+import { PostChannelRequestDto } from './dto/post/post.channel.request.dto';
+import { PostChannelJoinRequestDto } from './dto/post/post.channel.join.request.dto';
+import { UserService } from '../user/user.service';
+import { CHAT_MESSAGE } from './type/type.channel.action';
+import { PostChannelChatRequestDto } from './dto/post/post.channel.chat.request.dto';
+import { ChannelMeResponseDto } from './channel.me.response.dto';
+import { ChannelMeDto } from './dto/channel.me.dto';
+import { ChannelChatsResponseDto } from './channel.chats.response.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('/channels')
+export class ChannelNormalController {
+  constructor(
+    private readonly userServie: UserService,
+    private readonly channelService: ChannelNormalService,
+  ) {}
+
+  /* DM 대화 내역
+   * GET /channels?page={page}&count={count}&order={'recent' | 'popular'}&keyword={keyword | null}
+   * response body {
+   * 	channels: [
+   * 		{
+   * 			id: string;
+   * 			title: string; (중복 없음)
+   * 			access: 'public' | 'protected';
+   * 			headCount: number;
+   * 			maxCount: number;
+   * 		},
+   * 	]
+   * 	currentPage: number;
+   * 	totalPage: number;
+   * }
+   * response header {
+   * 	200: ok;
+   * }
+   * */
+  @Get('/')
+  async channelPageGet(
+    @Query('page') page: number,
+    @Query('count') count: number,
+    @Query('order') orderBy: OrderChannelType,
+    @Query('keyword') keyword: string,
+  ): Promise<ChannelPageResponseDto> {
+    const { channels, currentPage, totalPage } =
+      await this.channelService.getChannelPages({
+        page,
+        count,
+        orderBy,
+        keyword,
+      });
+
+    return { channels, currentPage, totalPage };
+  }
+
+  /**
+   * GET /channels/{roomId}/participants
+   * response body {
+   * 	me: {
+   * 		nickname: string;
+   * 		imgUrl: string;
+   * 		roleType: 'owner' | 'admin' | 'normal';
+   * 		isMuted: boolean;
+   * 	}
+   * 	participants: [
+   * 		{
+   * 			nickname: string;
+   * 			imgUrl: string;
+   * 			roleType: 'owner' | 'admin' | 'normal';
+   * 			isMuted: boolean;
+   * 		}...
+   * 	];
+   * 	headCount: number;
+   * 	maxCount: number;
+   * }
+   * response header {
+   * 	200: ok;
+   * }
+   */
+  @Get('/:roomId/participants')
+  @UseGuards(AuthGuard('jwt'))
+  async channelParticipantsGet(
+    @Requestor() requestor: UserIdCardDto,
+    @Query('roomId') channelId: string,
+  ): Promise<ChannelParticipantsResponseDto> {
+    const { id: userId } = requestor;
+    const { me, participants, headCount, maxCount } =
+      await this.channelService.getChannelParticipants({ userId, channelId });
+    return { me, participants, headCount, maxCount };
+  }
+
+  /**
+   * POST /channels
+   * request body {
+   * 	title: string;
+   * 	access: public | private;
+   * 	password: null | string;
+   * 	maxCount: number;
+   * }
+   * response header {
+   * 	200: ok;
+   * 	400: title taken;
+   * }
+   */
+  @Post('/')
+  @UseGuards(AuthGuard('jwt'))
+  async channelPost(
+    @Requestor() requestor: UserIdCardDto,
+    @Body() requestDto: PostChannelRequestDto,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    const { title, access, password, maxCount } = requestDto;
+
+    await this.channelService.postChannel({
+      userId,
+      title,
+      access,
+      password,
+      maxCount,
+    });
+  }
+
+  /**
+   * POST /channels/{roomId}/participants
+   * request body {
+   *     password: null | string;
+   * }
+   * response header {
+   * 	200: ok;
+   * 	400: full bang | wrong password | private | no bang;
+   * }
+   */
+  @Post('/:roomId/participants')
+  @UseGuards(AuthGuard('jwt'))
+  async channelParticipantPost(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+    @Body() requestDto: PostChannelJoinRequestDto,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    const { password } = requestDto;
+    await this.channelService.postChannelJoin({ userId, channelId, password });
+  }
+
+  /**
+   * DELETE /channels/{roomId}/participants
+   * response header {
+   * 	200: ok;
+   * 	400: no bang;
+   * }
+   */
+  @Delete('/:roomId/participants')
+  @UseGuards(AuthGuard('jwt'))
+  async channelParticipantDelete(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    await this.channelService.deleteChannelUser({ userId, channelId });
+  }
+
+  /**
+   * POST /channels/{roomId}/invitation/{nickname}
+   * response header {
+   * 	200: ok;
+   * 	400: no bang;
+   * }
+   */
+  @Post('/:roomId/invitation/:nickname')
+  @UseGuards(AuthGuard('jwt'))
+  async channelInvitationPost(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+    @Param('nickname') nickname: string,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    const { id: targetId } = await this.userServie.getIdFromNickname({
+      nickname,
+    });
+    await this.channelService.postInvite({ userId, channelId, targetId });
+  }
+
+  /**
+   * POST /channels/{roomId}/magicpass
+   * response header {
+   * 	200: ok;
+   *     400: full bang | no bang;
+   * }
+   */
+  @Post('/:roomId/magicpass')
+  @UseGuards(AuthGuard('jwt'))
+  async channelMagicPassPost(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    await this.channelService.postChannelAcceptInvite({ userId, channelId });
+  }
+
+  /**
+   * POST /channels/{roomId}/chats
+   * response body {
+   * 	message: string;
+   * }
+   * response header {
+   * 	200: ok;
+   * 	400: no bang;
+   * }
+   */
+  @Post('/:roomId/chats')
+  @UseGuards(AuthGuard('jwt'))
+  async channelChatPost(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+    @Body() requestDto: PostChannelChatRequestDto,
+  ): Promise<void> {
+    const { id: userId } = requestor;
+    const { message: content } = requestDto;
+    const type = CHAT_MESSAGE;
+    await this.channelService.postChannelMessage({
+      userId,
+      channelId,
+      content,
+      type,
+    });
+  }
+
+  /**
+   * GET /channels/me
+   * response body {
+   * 	myChannel: {
+   * 		id: string;
+   * 		title: string; (중복 없음)
+   * 		headCount: number;
+   * 		maxCount: number;
+   * 	} | null;
+   * }
+   * response header {
+   * 	200: ok;
+   * }
+   */
+  @Get('/me')
+  @UseGuards(AuthGuard('jwt'))
+  async channelMeGet(
+    @Requestor() requestor: UserIdCardDto,
+  ): Promise<ChannelMeResponseDto> {
+    const { id: userId } = requestor;
+    const myChannel: ChannelMeDto = await this.channelService.getChannelMy({
+      userId,
+    });
+    return { myChannel };
+  }
+
+  /**
+   * GET /channels/{roomId}chats?offset={offset}&count={count}
+   * response body {
+   * 	chats: [
+   * 		{
+   * 			id: number;
+   * 			message: string; // system인 경우 'mute' | 'unmute' | 'setadmin' | 'unsetadmin' | 'kick' | 'ban' | 'join' | 'leave'
+   * 			nickname: string; // system일 경우 당한사람
+   * 			time: Date;
+   * 			type: 'me' | 'others' | 'system';
+   * 		}, ...
+   * 	],
+   * 	isLastPage: boolean;
+   * }
+   * response header {
+   * 	200: ok;
+   * }
+   */
+  @Get('/:roomId/chats')
+  @UseGuards(AuthGuard('jwt'))
+  async channelChatsGet(
+    @Requestor() requestor: UserIdCardDto,
+    @Param('roomId') channelId: string,
+    @Query('offset') offset: number,
+    @Query('count') count: number,
+  ): Promise<ChannelChatsResponseDto> {
+    const { id: userId } = requestor;
+    const { chats, isLastPage } =
+      await this.channelService.getChannelMessageHistory({
+        userId,
+        channelId,
+        offset,
+        count,
+      });
+    return { chats, isLastPage };
+  }
+}

--- a/src/domain/channel/dto/channel-participant.dto.ts
+++ b/src/domain/channel/dto/channel-participant.dto.ts
@@ -25,7 +25,7 @@ export class ChannelParticipantDto {
   }
 }
 
-export class ChannelParticipantDtos {
+export class ChannelParticipantsDto {
   me: ChannelParticipantDto;
   participants: ChannelParticipantDto[] = [];
   headCount: number;

--- a/src/domain/channel/dto/channel.page.dto.ts
+++ b/src/domain/channel/dto/channel.page.dto.ts
@@ -1,5 +1,4 @@
 import { Channel } from 'src/domain/channel/entity/channel.entity';
-import { ChannelModel } from 'src/domain/factory/model/channel.model';
 import { ChannelType } from 'src/domain/channel/type/type.channel';
 import { Page } from 'src/global/utils/page';
 

--- a/src/domain/channel/dto/channel.page.response.dto.ts
+++ b/src/domain/channel/dto/channel.page.response.dto.ts
@@ -1,0 +1,7 @@
+import { ChannelPageDto } from './channel.page.dto';
+
+export class ChannelPageResponseDto {
+  channels: ChannelPageDto[];
+  currentPage: number;
+  totalPage: number;
+}

--- a/src/domain/channel/dto/channel.participant.request.dto.ts
+++ b/src/domain/channel/dto/channel.participant.request.dto.ts
@@ -1,0 +1,8 @@
+import { ChannelParticipantDto } from './channel-participant.dto';
+
+export class ChannelParticipantsResponseDto {
+  me: ChannelParticipantDto;
+  participants: ChannelParticipantDto[] = [];
+  headCount: number;
+  maxCount: number;
+}

--- a/src/domain/channel/dto/post/post.channel.chat.request.dto.ts
+++ b/src/domain/channel/dto/post/post.channel.chat.request.dto.ts
@@ -1,0 +1,3 @@
+export class PostChannelChatRequestDto {
+  message: string;
+}

--- a/src/domain/channel/dto/post/post.channel.dto.ts
+++ b/src/domain/channel/dto/post/post.channel.dto.ts
@@ -2,7 +2,7 @@ import { ChannelType } from 'src/domain/channel/type/type.channel';
 
 export class PostChannelDto {
   userId: number;
-  name: string;
+  title: string;
   access: ChannelType;
   password: string;
   maxCount: number;

--- a/src/domain/channel/dto/post/post.channel.join.request.dto.ts
+++ b/src/domain/channel/dto/post/post.channel.join.request.dto.ts
@@ -1,0 +1,3 @@
+export class PostChannelJoinRequestDto {
+  password: string;
+}

--- a/src/domain/channel/dto/post/post.channel.request.dto.ts
+++ b/src/domain/channel/dto/post/post.channel.request.dto.ts
@@ -1,0 +1,6 @@
+export class PostChannelRequestDto {
+  title: string;
+  access: 'public' | 'private';
+  password: string | null;
+  maxCount: number;
+}

--- a/src/domain/channel/dto/post/post.invite.dto.ts
+++ b/src/domain/channel/dto/post/post.invite.dto.ts
@@ -1,5 +1,5 @@
 export class PostInviteDto {
   userId: number;
   channelId: string;
-  tragetId: number;
+  targetId: number;
 }

--- a/src/domain/channel/dto/post/save.channel.dto.ts
+++ b/src/domain/channel/dto/post/save.channel.dto.ts
@@ -13,7 +13,7 @@ export class SaveChannelDto {
   maxCount: number;
 
   static from(dto: PostChannelDto): SaveChannelDto {
-    const { userId, name, maxCount } = dto;
+    const { userId, title: name, maxCount } = dto;
     let type: ChannelType = dto.access;
     if (type === CHANNEL_PUBLIC && dto.password) type = CHANNEL_PROTECTED;
     let password: string = null;

--- a/src/domain/channel/service/channel.normal.service.ts
+++ b/src/domain/channel/service/channel.normal.service.ts
@@ -44,7 +44,7 @@ import { FindChannelMessagePageDto } from '../dto/get/find.channel-message.page.
 import { GetChannelParticipantsDto } from '../dto/get/get.channel-participants.dto';
 import {
   ChannelParticipantDto,
-  ChannelParticipantDtos,
+  ChannelParticipantsDto,
 } from '../dto/channel-participant.dto';
 import { GetChannelMyDto } from '../dto/get/get.channel.my.dto';
 import { ChannelMeDto } from '../dto/channel.me.dto';
@@ -80,14 +80,14 @@ export class ChannelNormalService {
    */
   getChannelParticipants(
     getDto: GetChannelParticipantsDto,
-  ): ChannelParticipantDtos {
+  ): ChannelParticipantsDto {
     const channel: ChannelModel = this.channelFactory.findById(
       getDto.channelId,
     );
     const users: UserModel[] = this.channelFactory.getUsers(channel.id);
     checkUserInChannel(channel, getDto.userId);
 
-    const responseDto: ChannelParticipantDtos = new ChannelParticipantDtos();
+    const responseDto: ChannelParticipantsDto = new ChannelParticipantsDto();
     users.map((user) => {
       if (user.id === getDto.userId) {
         responseDto.me = ChannelParticipantDto.fromModel(user);
@@ -127,7 +127,7 @@ export class ChannelNormalService {
     checkChannelExist(channel);
 
     const host: UserModel = this.userFactory.findById(postDto.userId);
-    const target: UserModel = this.userFactory.findById(postDto.tragetId);
+    const target: UserModel = this.userFactory.findById(postDto.targetId);
     checkUserExist(host);
     checkUserExist(target);
 
@@ -205,7 +205,7 @@ export class ChannelNormalService {
    */
   @Transactional({ isolationLevel: IsolationLevel.REPEATABLE_READ })
   async postChannel(postDto: PostChannelDto): Promise<void> {
-    await checkChannelNameIsDuplicate(this.channelRepository, postDto.name);
+    await checkChannelNameIsDuplicate(this.channelRepository, postDto.title);
 
     this.exitIfUserIsInChannel(postDto.userId);
 

--- a/src/domain/channel/test/channel.normal.service.spec.ts
+++ b/src/domain/channel/test/channel.normal.service.spec.ts
@@ -41,7 +41,7 @@ import { ChannelMessagesHistoryDto } from '../dto/channel-message.history.dto';
 import { GetChannelPageDto } from '../dto/get/get.channel.page.dto';
 import { ChannelPageDtos } from '../dto/channel.page.dto';
 import { GetChannelParticipantsDto } from '../dto/get/get.channel-participants.dto';
-import { ChannelParticipantDtos } from '../dto/channel-participant.dto';
+import { ChannelParticipantsDto } from '../dto/channel-participant.dto';
 import { PostChannelDto } from '../dto/post/post.channel.dto';
 import { PostChannelJoinDto } from '../dto/post/post.channel.join.dto';
 import { PostInviteDto } from '../dto/post/post.invite.dto';
@@ -253,7 +253,7 @@ describe('ChannelUserService', () => {
           channelId: basicChannel.id,
         };
 
-        const participants: ChannelParticipantDtos =
+        const participants: ChannelParticipantsDto =
           await service.getChannelParticipants(getChannelParticipantsRequest);
 
         expect(participants).toHaveProperty('me');
@@ -279,7 +279,7 @@ describe('ChannelUserService', () => {
           channelId: channel.id,
         };
 
-        const participants: ChannelParticipantDtos =
+        const participants: ChannelParticipantsDto =
           service.getChannelParticipants(getChannelParticipantsRequest);
 
         expect(participants).toHaveProperty('me');
@@ -317,7 +317,7 @@ describe('ChannelUserService', () => {
         const user = await testData.createBasicUser('user');
         const postChannelRequest: PostChannelDto = {
           userId: user.id,
-          name: 'channel',
+          title: 'channel',
           access: CHANNEL_PUBLIC,
           password: null,
           maxCount: 10,
@@ -330,9 +330,9 @@ describe('ChannelUserService', () => {
         });
 
         expect(savedChannelDb.operator.id).toBe(user.id);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.type).toBe(postChannelRequest.access);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.password).toBe(null);
         expect(savedChannelDb.maxHeadCount).toBe(postChannelRequest.maxCount);
 
@@ -341,9 +341,9 @@ describe('ChannelUserService', () => {
         );
 
         expect(savedChannelFt.ownerId).toBe(user.id);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.type).toBe(postChannelRequest.access);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.password).toBe(null);
         expect(savedChannelFt.maxHeadCount).toBe(postChannelRequest.maxCount);
       });
@@ -352,7 +352,7 @@ describe('ChannelUserService', () => {
         const user = await testData.createBasicUser('user');
         const postChannelRequest: PostChannelDto = {
           userId: user.id,
-          name: 'channel',
+          title: 'channel',
           access: CHANNEL_PROTECTED,
           password: 'null',
           maxCount: 10,
@@ -365,9 +365,9 @@ describe('ChannelUserService', () => {
         });
 
         expect(savedChannelDb.operator.id).toBe(user.id);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.type).toBe(postChannelRequest.access);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.password).toBe(postChannelRequest.password);
         expect(savedChannelDb.maxHeadCount).toBe(postChannelRequest.maxCount);
 
@@ -376,9 +376,9 @@ describe('ChannelUserService', () => {
         );
 
         expect(savedChannelFt.ownerId).toBe(user.id);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.type).toBe(postChannelRequest.access);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.password).toBe(postChannelRequest.password);
         expect(savedChannelFt.maxHeadCount).toBe(postChannelRequest.maxCount);
       });
@@ -387,7 +387,7 @@ describe('ChannelUserService', () => {
         const user = await testData.createBasicUser('user');
         const postChannelRequest: PostChannelDto = {
           userId: user.id,
-          name: 'channel',
+          title: 'channel',
           access: CHANNEL_PRIVATE,
           password: 'null',
           maxCount: 10,
@@ -400,9 +400,9 @@ describe('ChannelUserService', () => {
         });
 
         expect(savedChannelDb.operator.id).toBe(user.id);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.type).toBe(postChannelRequest.access);
-        expect(savedChannelDb.name).toBe(postChannelRequest.name);
+        expect(savedChannelDb.name).toBe(postChannelRequest.title);
         expect(savedChannelDb.password).toBe(null);
         expect(savedChannelDb.maxHeadCount).toBe(postChannelRequest.maxCount);
 
@@ -411,9 +411,9 @@ describe('ChannelUserService', () => {
         );
 
         expect(savedChannelFt.ownerId).toBe(user.id);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.type).toBe(postChannelRequest.access);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.password).toBe(null);
         expect(savedChannelFt.maxHeadCount).toBe(postChannelRequest.maxCount);
       });
@@ -423,14 +423,14 @@ describe('ChannelUserService', () => {
         const user2 = await testData.createBasicUser('user2');
         const postChannelRequest: PostChannelDto = {
           userId: user.id,
-          name: 'channel',
+          title: 'channel',
           access: CHANNEL_PUBLIC,
           password: null,
           maxCount: 10,
         };
         const duplicatedRequest: PostChannelDto = {
           userId: user2.id,
-          name: 'channel',
+          title: 'channel',
           access: CHANNEL_PUBLIC,
           password: null,
           maxCount: 10,
@@ -443,13 +443,13 @@ describe('ChannelUserService', () => {
         );
 
         const savedChannelFt: ChannelModel = channelFactory.findByChannelName(
-          duplicatedRequest.name,
+          duplicatedRequest.title,
         );
 
         expect(savedChannelFt.ownerId).toBe(user.id);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.type).toBe(postChannelRequest.access);
-        expect(savedChannelFt.name).toBe(postChannelRequest.name);
+        expect(savedChannelFt.name).toBe(postChannelRequest.title);
         expect(savedChannelFt.password).toBe(null);
         expect(savedChannelFt.maxHeadCount).toBe(postChannelRequest.maxCount);
       });
@@ -616,7 +616,7 @@ describe('ChannelUserService', () => {
         const inviteRequest: PostInviteDto = {
           userId: basicChannel.ownerId,
           channelId: basicChannel.id,
-          tragetId: user.id,
+          targetId: user.id,
         };
 
         service.postInvite(inviteRequest);


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#116 
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 일반 유저용 channel controller 작성
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- GET /channels?page={page}&count={count}&order={'recent' | 'popular'}&keyword={keyword | null}
- GET /channels/{roomId}/participants
- POST /channels
- POST /channels/{roomId}/participants
- DELETE /channels/{roomId}/participants
- POST /channels/{roomId}/invitation/{nickname}
- POST /channels/{roomId}/magicpass
- POST /channels/{roomId}/chats
- GET /channels/me
- GET /channels/{roomId}chats?offset={offset}&count={count}