### PR TITLE
[fix] offset skip 대신에 where절에 LessThan 사용, order id Desc 추가 #123

### DIFF
--- a/src/domain/direct-message/direct-message.repository.ts
+++ b/src/domain/direct-message/direct-message.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { DirectMessage } from './direct-message.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThan, Repository } from 'typeorm';
+import { LessThan, MoreThan, Repository } from 'typeorm';
 import { FriendChatManager } from 'src/global/utils/generate.room.id';
 
 @Injectable()
@@ -27,13 +27,16 @@ export class DirectMessageRepository {
   ): Promise<DirectMessage[]> {
     const directMessages: DirectMessage[] = await this.repository.find({
       where: {
+        id: LessThan(offset),
         roomId: FriendChatManager.generateRoomId(
           userId.toString(),
           friendId.toString(),
         ),
       },
-      skip: offset,
       take: count,
+      order: {
+        id: 'DESC',
+      },
     });
     return directMessages;
   }


### PR DESCRIPTION

## Issue
+ Issue Number: <!-- #issue --> #123
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
디엠 레포 손봤습니다!
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- offset skip 대신에 where절에 LessThan 사용
- order id Desc 추가 (DM은 아이디 역순으로 갑니다!)
- 이에 따른 테스트 수정

