### PR TITLE
[Fix] 채널 여러개 만드는 부분 인자 받도록 수정

### DIFF
--- a/src/domain/channel/test/channel.test.service.ts
+++ b/src/domain/channel/test/channel.test.service.ts
@@ -150,8 +150,8 @@ export class ChannelTestService {
     return this.channelFactory.findById(channel.id);
   }
 
-  async createBasicChannels(): Promise<void> {
-    for (let i = 1; i < 10; i++) {
+  async createBasicChannels(userNum: number): Promise<void> {
+    for (let i = 1; i < userNum; i++) {
       await this.createBasicChannel('name' + i.toString(), i);
     }
   }


### PR DESCRIPTION
## Summary
<!-- 해당 기능에 대한 요약글 -->
- channelTestService의 createBasicChannels() 함수에서 기본적으로 10개 만들던거 -> 인자로 숫자를 받아 숫자만큼 만드는 방법으로 변경
