### PR TITLE
[fix] 친구가 두 개 생기는 버그 해결.. #145

### DIFF
--- a/src/domain/friend/friend.repository.ts
+++ b/src/domain/friend/friend.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { In, Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { Friend } from './friend.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
@@ -119,9 +119,8 @@ export class FriendRepository {
     });
   }
 
-  async updateFriendStatusFromToBySenderIdAndReceiverId(
-    from: FriendType,
-    to: FriendType,
+  async updateFriendStatusBySenderIdAndReceiverId(
+    status: FriendType,
     senderId: number,
     receiverId: number,
   ): Promise<void> {
@@ -129,12 +128,11 @@ export class FriendRepository {
       {
         sender: { id: senderId },
         receiver: { id: receiverId },
-        status: from,
+        status: Not(FRIENDSTATUS_DELETED),
       },
-      { status: to },
+      { status: status },
     );
   }
-
   async hardDeleteFriendBySenderIdAndReceiverId(
     senderId: number,
     receiverId: number,

--- a/src/domain/friend/friend.service.ts
+++ b/src/domain/friend/friend.service.ts
@@ -119,8 +119,7 @@ export class FriendService {
 
     if (!isRequesting) return;
 
-    await this.friendRepository.updateFriendStatusFromToBySenderIdAndReceiverId(
-      FRIENDSTATUS_PENDING,
+    await this.friendRepository.updateFriendStatusBySenderIdAndReceiverId(
       FRIENDSTATUS_FRIEND,
       friendId,
       userId,
@@ -152,8 +151,7 @@ export class FriendService {
 
     if (!isRequesting) return;
 
-    await this.friendRepository.updateFriendStatusFromToBySenderIdAndReceiverId(
-      FRIENDSTATUS_PENDING,
+    await this.friendRepository.updateFriendStatusBySenderIdAndReceiverId(
       FRIENDSTATUS_DELETED,
       friendId,
       userId,
@@ -177,8 +175,7 @@ export class FriendService {
 
     if (!friend) return;
 
-    await this.friendRepository.updateFriendStatusFromToBySenderIdAndReceiverId(
-      FRIENDSTATUS_FRIEND,
+    await this.friendRepository.updateFriendStatusBySenderIdAndReceiverId(
       FRIENDSTATUS_DELETED,
       friend.sender.id,
       friend.receiver.id,


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #145
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
FriendStatus를 Update하는 메서드를, 바뀌어야 할 상태만 받다가 이제 바뀌기 전 상태도 받아 에러가 없도록 했습니다.
어떨까요? 

## Changed Logic
<!-- 고친 사항(아닌 경우 삭제) -->
기존에는 id들로만 찾아서 update하니까 deleted들도 다 모여서 Update됐는데, 이제 id + 상태로 찾아서 Pending만 골라서 업뎃합니다.
## Etc
