### PR TITLE
[Fix] 친구 서비스 차단 당했을때 백에서 씹기 #167

### DIFF
--- a/src/domain/friend/friend.service.ts
+++ b/src/domain/friend/friend.service.ts
@@ -71,33 +71,6 @@ export class FriendService {
     );
   }
 
-  async checkRequestable(userId: number, friendId: number): Promise<boolean> {
-    const isFriend: boolean =
-      await this.friendRepository.checkIsFriendByUserIdAndFriendId(
-        userId,
-        friendId,
-      );
-    const isRequesting =
-      await this.friendRepository.checkIsPendingBySenderIdAndReceiverId(
-        userId,
-        friendId,
-      );
-    const isBlocked =
-      await this.blockRepository.checkIsBlockByUserIdAndTargetId(
-        userId,
-        friendId,
-      );
-    const isBlockedByTarget =
-      await this.blockRepository.checkIsBlockByUserIdAndTargetId(
-        friendId,
-        userId,
-      );
-
-    if (isFriend || isRequesting || isBlocked || isBlockedByTarget)
-      return false;
-    return true;
-  }
-
   /**친구 요청 목록
    * 사용자의 친구 요청 목록을 nickname을 기준으로 오름차순으로 정렬합니다.
    */
@@ -218,8 +191,41 @@ export class FriendService {
     return responseDto;
   }
 
-  checkIfRequestorIsTarget(requestorId: number, targetId: number): void {
+  private checkIfRequestorIsTarget(
+    requestorId: number,
+    targetId: number,
+  ): void {
     if (requestorId === targetId)
       throw new BadRequestException('Cannot request yourself');
+  }
+
+  private async checkRequestable(
+    userId: number,
+    friendId: number,
+  ): Promise<boolean> {
+    const isFriend: boolean =
+      await this.friendRepository.checkIsFriendByUserIdAndFriendId(
+        userId,
+        friendId,
+      );
+    const isRequesting =
+      await this.friendRepository.checkIsPendingBySenderIdAndReceiverId(
+        userId,
+        friendId,
+      );
+    const isBlocked =
+      await this.blockRepository.checkIsBlockByUserIdAndTargetId(
+        userId,
+        friendId,
+      );
+    const isBlockedByTarget =
+      await this.blockRepository.checkIsBlockByUserIdAndTargetId(
+        friendId,
+        userId,
+      );
+
+    if (isFriend || isRequesting || isBlocked || isBlockedByTarget)
+      return false;
+    return true;
   }
 }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
    #167
+ PR Type: `fix`
## Summary
<!-- 해당 기능에 대한 요약글 -->
찬구 추가를 차단당했을때 친구추가 못하도록 로직 생성
## Changed Logic
내가 차단 당했을때 친구추가가 가던 이슈 해결을 위해 차단당했는지 체크하는 로직 생성