### PR TITLE
[Refactor / Test] 테스트코드 보완하기 - 유저 입장하는 부분, 확인할거 추가적으로 꼼꼼하게 보기 #184

### DIFF
--- a/src/test/domain/channel/channel.normal.service.spec.ts
+++ b/src/test/domain/channel/channel.normal.service.spec.ts
@@ -134,6 +134,14 @@ describe('ChannelUserService', () => {
   });
 
   describe('일반 유저 기능', () => {
+    /**
+     * 채팅방 목록 조회
+     * 채팅방 목록은 최신순, 인기순으로 조회할 수 있다.
+     * 채팅방 목록은 검색이 가능하다.
+     * 인기순으로 조회할 경우, 채팅방의 인원수가 많은 순으로 조회한다.
+     * 최신순으로 조회할 경우, 최근에 만들어진 채팅방 순으로 조회한다.
+     * 검색어가 있을 경우, 채팅방의 제목에서 검색어를 포함하는 채팅방만 조회한다.
+     */
     describe('채팅방 목록 조회', () => {
       it('[Valid Case] 채팅방 목록 조회(resent)', async () => {
         await channelData.createBasicChannels(10);
@@ -248,6 +256,11 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅방 참여자 목록 조회
+     * 나의 정보를 포함한 채팅방 참여자 목록을 조회한다.
+     * 채팅방에 참여하지 않은 경우, 채팅방 참여자 목록을 조회할 수 없다.
+     */
     describe('채팅방 참여자 목록 조회', () => {
       it('[Valid Case] 채팅방 참여자 목록 조회 (기본)', async () => {
         const basicChannel: ChannelModel = await channelData.createBasicChannel(
@@ -325,6 +338,16 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅방 생성
+     * public 채팅방은 비밀번호가 없어야 한다.
+     * 비밀번호가 있으면 비밀번호가 있는 protected채팅방이다.
+     * private 채팅방은 비밀번호가 없다.
+     * 이름이 같은 채팅방이 있으면 생성할 수 없다.
+     * 채팅방 생성시 채팅방에 참여한다.
+     * 채팅방 생성시 채팅방에 참여한 유저는 owner이다.
+     * 이미 참여한 채팅방이 있으면 기존 채팅방에서 나간다.
+     */
     describe('채팅방 생성', () => {
       it('[Valid Case] 채팅방 생성(public)', async () => {
         const user: User = await userData.createUser('user');
@@ -563,6 +586,17 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅방 입장
+     * public 채팅방에는 아무렇게나 입장할 수 있다.
+     * private 채팅방에는 비밀번호를 입력해야 입장할 수 있다.
+     * protected 채팅방에는 일반 입장으로는 입장할 수 없다. (초대가 있어야 함)
+     * UserModel의 joinedChannel에 채팅방의 id가 추가된다.
+     * 채팅방에 유저가 추가되면, 채팅방의 유저 수가 1 증가한다.
+     * 채팅방에 유저가 추가되면, 채팅방의 유저 목록에 유저가 추가된다.
+     * 이미 채팅방에 참여중인 유저가 다른 채팅방에 입장하면, 기존 채팅방에서는 나간다.
+     * ban된 유저는 채팅방에 입장할 수 없다.
+     */
     describe('채팅방 입장', () => {
       it('[Valid Case] public 채팅방 입장', async () => {
         const user: User = await userData.createUser('user');
@@ -760,6 +794,18 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅방 초대
+     * 유저를 초대하면 UserModel의 inviteList에 초대받은 채팅방이 추가되어야 한다.
+     * 초대를 수락하면 UserModel의 inviteList에서 해당 채팅방이 삭제되어야 한다.
+     * 초대를 거절하면 UserModel의 inviteList에서 해당 채팅방이 삭제되어야 한다.
+     * 초대를 수락하면 채널 입장 성공과 동일하게 처리된다.
+     * 초대를 거절하면 ChannelUser에 유저가 추가되지 않아야 한다.
+     * 초대를 거절하면 Channel의 headCount가 증가하지 않아야 한다.
+     * 초대를 거절하면 ChannelModel의 users에 유저가 추가되지 않아야 한다.
+     * 채널의 정원이 초과되면 초대를 수락해도 채널에 입장할 수 없다.
+     * 채널에서 ban된 유저는 초대를 수락할 수 없다.
+     */
     describe('채팅방 초대', () => {
       it('[Valid Case] 일반 유저 초대', async () => {
         const basicChannel: ChannelModel = await channelData.createBasicChannel(
@@ -1056,6 +1102,10 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅 전송
+     * 채팅이 전송되면 채팅 메시지가 저장되어야 한다.
+     */
     describe('채팅 전송', () => {
       it('[Valid Case] 채팅 전송', async () => {
         const user: UserModel = await channelData.createUserInChannel(9);
@@ -1075,9 +1125,11 @@ describe('ChannelUserService', () => {
               channel: { id: user.joinedChannel },
               type: CHAT_MESSAGE,
             },
+            order: { id: 'DESC' },
           });
         expect(savedMessage.content).toBe('hi');
       });
+
       it('[Error Case] 채팅 전송(Mute된 경우)', async () => {
         const user: UserModel = await channelData.createMutedUserInChannel(9);
         const postMessageRequest: PostChannelMessageDto = {
@@ -1101,6 +1153,17 @@ describe('ChannelUserService', () => {
       });
     });
 
+    /**
+     * 채팅방에서 퇴장하면 채팅방의 인원수가 줄어든다.
+     * 채팅방의 인원수가 0이 되면 채팅방이 삭제된다.
+     * owner가 퇴장하면 채팅방의 owner가 없어진다
+     * 채팅방의 owner가 없어져도 채팅방은 존재한다
+     * 다시 owner가 들어와도 채팅방의 owner가 되지 않는다
+     * admin이 퇴장하면 adminList에서 제거된다
+     * 다시 입장하면 adminList에 추가되지 않는다
+     * 채널에서는 mute된 유저가 퇴장해도 mute가 풀리지 않는다.
+     * 유저의 isMuted는 채널에서 mute된 경우에만 true이다.
+     */
     describe('채팅방 퇴장', () => {
       it('[Valid Case] 일반 유저가 퇴장하는 경우', async () => {
         const user: UserModel = await channelData.createUserInChannel(9);
@@ -1130,22 +1193,28 @@ describe('ChannelUserService', () => {
         );
 
         expect(savedChannelFt.users.has(user.id)).toBe(false);
+
+        const savedUserFt: UserModel = userFactory.findById(user.id);
+
+        expect(savedUserFt.joinedChannel).toBe(null);
       });
+
       it('[Valid Case] owner가 퇴장하는 경우', async () => {
         const channel: ChannelModel = await channelData.createBasicChannel(
           'channel',
           5,
         );
+        const user: UserModel = userFactory.findById(channel.ownerId);
 
         const deleteChannelUserRequest: DeleteChannelUserDto = {
-          userId: channel.ownerId,
+          userId: user.id,
           channelId: channel.id,
         };
 
         await service.deleteChannelUser(deleteChannelUserRequest);
         const channelUserDb: ChannelUser = await channelUserRepository.findOne({
           where: {
-            user: { id: channel.ownerId },
+            user: { id: user.id },
             channel: { id: channel.id },
           },
         });
@@ -1157,8 +1226,12 @@ describe('ChannelUserService', () => {
           channel.id,
         );
 
-        expect(savedChannelFt.users.has(channel.ownerId)).toBe(false);
+        expect(savedChannelFt.users.has(user.id)).toBe(false);
         expect(savedChannelFt.ownerId).toBe(null);
+
+        const savedUserFt: UserModel = userFactory.findById(user.id);
+
+        expect(savedUserFt.joinedChannel).toBe(null);
       });
 
       it('[Valid Case] admin이 퇴장하는 경우', async () => {
@@ -1191,8 +1264,13 @@ describe('ChannelUserService', () => {
 
         expect(savedChannelFt.users.has(admin.id)).toBe(false);
         expect(savedChannelFt.users.size).toBe(8);
+
+        const savedUserFt: UserModel = userFactory.findById(admin.id);
+
+        expect(savedUserFt.joinedChannel).toBe(null);
       });
-      it('[Valid Case] mute 된 유저가 퇴장하는 경우(mute 상태 유지)', async () => {
+
+      it('[Valid Case] mute 된 유저가 퇴장하는 경우', async () => {
         const user: UserModel = await channelData.createMutedUserInChannel(9);
         const channel: ChannelModel = channelFactory.findById(
           user.joinedChannel,
@@ -1220,10 +1298,55 @@ describe('ChannelUserService', () => {
 
         expect(savedChannelFt.users.has(user.id)).toBe(false);
         expect(savedChannelFt.muteList.get(user.id)).toBe(user.id);
+
+        const savedUserFt: UserModel = userFactory.findById(user.id);
+
+        expect(savedUserFt.joinedChannel).toBe(null);
+        expect(savedUserFt.isMuted).toBe(false);
+      });
+
+      it('[Valid Case] 모든 유저가 퇴장하는 경우', async () => {
+        const channel: ChannelModel = await channelData.createBasicChannel(
+          'channels',
+          1,
+        );
+        const user: UserModel = userFactory.findById(channel.ownerId);
+
+        const deleteChannelUserRequest: DeleteChannelUserDto = {
+          userId: user.id,
+          channelId: channel.id,
+        };
+
+        await service.deleteChannelUser(deleteChannelUserRequest);
+
+        const channelUserDb: ChannelUser[] = await channelUserRepository.find({
+          where: {
+            user: { id: user.id },
+            channel: { id: channel.id },
+            isDeleted: false,
+          },
+        });
+
+        expect(channelUserDb.length).toBe(0);
+
+        const savedChannelFt: ChannelModel = channelFactory.findById(
+          channel.id,
+        );
+        expect(savedChannelFt).toBe(undefined);
+        const savedUserFt: UserModel = userFactory.findById(user.id);
+        expect(savedUserFt.joinedChannel).toBe(null);
       });
     });
   });
 
+  /**
+   * 채팅방의 채팅 내역을 조회한다.
+   * 채팅방에 입장한 유저만 채팅 내역을 조회할 수 있다.
+   * 채팅 내역은 최신순으로 정렬되어야 한다.
+   * 채팅 내역은 count로 받은 개수만큼 조회할 수 있다.
+   * 채팅 내역은 offset으로 받은 number 이전의 id만 조회할 수 있다.
+   * 마지막 페이지인 경우 isLastPage는 true이다.
+   */
   describe('채팅방 채팅 내역 조회', () => {
     it('[Valid Case] 일반 유저의 채팅 내역 조회 (last page 아닌 경우)', async () => {
       const channel: ChannelModel =


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#184 
+ PR Type: `test`, `refactor`
## Summary
<!-- 해당 기능에 대한 요약글 -->
- 채널 관련 테스트코드 보완하기 - 유저 입장하는 부분, 데이터 확인할거 추가적으로 꼼꼼하게 보기

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- findOne()으로 조회하던 부분 find()로 조회해서 1개만 저장되어있는지 확인
- 테스트케이스가 추가되었음
    - 기존에 채널에 있던 유저가 다른 채널에 입장시 퇴장되는지 확인하는 케이스
    - 초대 수락시에도 퇴장을 잘 하는지 확인
    - 채널 생성시에도 퇴장 잘 하는지 확인
    - 채널 퇴장시 인원이 0명이 되면 채널이 삭제되는지 확인하는 케이스
    - 테스트코드에 주석이 추가되었습니다
- 테스트케이스에서 검사 안하던 부분들을 더 자세하게 검사하도록 추가했습니다
    - factory만 검사하던거 -> db, factory 모두 확인하는 케이스 추가
