### PR TITLE
[feat] friend status socket으로 쏴주기 #197

### DIFF
--- a/src/gateway/friend.gateway.ts
+++ b/src/gateway/friend.gateway.ts
@@ -50,7 +50,6 @@ export class FriendGateWay implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('status')
-  @Transactional({ isolationLevel: IsolationLevel.REPEATABLE_READ })
   async emitFriendStatus(
     @ConnectedSocket() socket: Socket,
   ): Promise<void> {


### PR DESCRIPTION
## Issue
+ Issue Number: https://github.com/Dr-Pong/dr_pong_chat_server/issues/197
+ PR Type: `feat`

## Summary
<!-- 해당 기능에 대한 요약글 -->
실례합니다.. 익스큐제모아
클라이언트가 친구의 status를 달라고 emit 했을 때 친구의 status를 쏴주는 로직을 추가했어요.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
status라는 key를 구독하고 있다가 클라이언트가 요청했을 때 클라이언트에게 연결된 소켓으로 모든 친구의 status를 emit 해줍니다.

## Etc
