### PR TITLE
[Fix] game invite 로직 수정 및 리팩토링 #215

### DIFF
--- a/src/domain/factory/user.factory.ts
+++ b/src/domain/factory/user.factory.ts
@@ -161,9 +161,9 @@ export class UserFactory {
     return Array.from(user.gameInviteList.values());
   }
 
-  deleteGameInvite(senderId: number, receiverId: number): void {
+  deleteGameInviteBySenderId(senderId: number): void {
     const sender: UserModel = this.findById(senderId);
-    const receiver: UserModel = this.findById(receiverId);
+    const receiver: UserModel = this.findById(sender?.gameInvite?.receiverId);
     if (!sender || !receiver) return;
     receiver.gameInviteList.delete(sender.gameInvite.id);
     sender.gameInvite = null;

--- a/src/domain/invitation/invitation.service.ts
+++ b/src/domain/invitation/invitation.service.ts
@@ -171,12 +171,7 @@ export class InvitationService {
   }
 
   async deleteGameInvite(deleteDto: DeleteGameInviteDto): Promise<void> {
-    const { senderId } = deleteDto;
-    const sendUser: UserModel = this.userFactory.findById(senderId);
-    const receivedUser: UserModel = this.userFactory.findById(
-      sendUser?.gameInvite?.receiverId,
-    );
-    this.notificationGateWay.deleteGameInvite(sendUser.id, receivedUser?.id);
+    this.notificationGateWay.deleteGameInvite(deleteDto?.senderId);
   }
 
   async postGameInviteAccept(
@@ -186,8 +181,8 @@ export class InvitationService {
     const acceptUser: UserModel = this.userFactory.findById(userId);
     const invitation: GameInviteModel = acceptUser.gameInviteList.get(inviteId);
     validateInvite(invitation);
-    this.deleteGameInvite({ senderId: invitation.senderId });
     acceptUser.playingGame = await this.postGameFromInvitation(invitation);
+    this.userFactory.deleteGameInviteBySenderId(invitation.senderId);
     return new GameInviteAcceptResponseDto(acceptUser.playingGame.id);
   }
 
@@ -199,7 +194,7 @@ export class InvitationService {
     const invitation: GameInviteModel = receiver.gameInviteList.get(inviteId);
 
     const sender = this.userFactory.findById(invitation?.senderId);
-    this.notificationGateWay.deleteGameInvite(sender.id, receiver.id);
+    this.notificationGateWay.deleteGameInvite(sender.id);
   }
 
   /**

--- a/src/gateway/notification.gateway.ts
+++ b/src/gateway/notification.gateway.ts
@@ -110,12 +110,15 @@ export class NotificationGateWay
     this.userFactory.inviteGame(sender.id, receiver.id, invite);
   }
 
-  async deleteGameInvite(senderId: number, receiverId: number) {
+  async deleteGameInvite(senderId: number) {
     const sender: UserModel = this.userFactory.findById(senderId);
-    const receiver: UserModel = this.userFactory.findById(receiverId);
+    const receiver: UserModel = this.userFactory.findById(
+      sender?.gameInvite?.receiverId,
+    );
+    if (!sender || !receiver) return;
     sender.socket[GATEWAY_NOTIFICATION]?.emit('deleteInvite', {});
     receiver.socket[GATEWAY_NOTIFICATION]?.emit('deleteInvite', {});
-    this.userFactory.deleteGameInvite(sender.id, receiver.id);
+    this.userFactory.deleteGameInviteBySenderId(sender.id);
   }
 
   /**


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#215
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 게임 초대 수락 로직 일부 수정
## Detail
<!-- 해당 기능에 대한 상세 요소-->
- `userFactory.deleteInvite()` 코드에서 senderId, receiverId 둘다 받던걸 senderId만 받도록 수정 (senderId는 하나만 있으니까)
- `gameInviteAccept()` 함수 작동 순서 변경
    - 기존 : 초대delete 하고 나서 게임 생성
    - 변경 : 게임 생성하고 나서 초대 delete
- 우려사항 : 초대 수락을 2번 병렬로 보내면 게임 2개 생성되면서 서버 터질 수 있을것같음. 뮤텍스 쓰던가 해야될듯..??