### PR TITLE
[Fix] 채널 목록 totalpage가 잘못 나오는 문제 #251

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -92,7 +92,7 @@ jobs:
         run: docker-compose build
       
       - name: Run Docker Container
-        run: docker-compose up -d
+        run: docker-compose up -d chatserver
       
       - name: Test 
         run: npm test -- --bail

--- a/src/domain/channel/repository/channel.repository.ts
+++ b/src/domain/channel/repository/channel.repository.ts
@@ -66,7 +66,7 @@ export class ChannelRepository {
 
     const page: Page<Channel[]> = new Page();
     page.content = channels;
-    page.totalPage = Math.floor(totalChannels / findDto.count) + 1;
+    page.totalPage = Math.floor(totalChannels / (findDto.count + 1)) + 1;
     page.currentPage =
       findDto.page > page.totalPage ? page.totalPage : findDto.page;
 
@@ -102,7 +102,7 @@ export class ChannelRepository {
 
     const page: Page<Channel[]> = new Page();
     page.content = channels;
-    page.totalPage = Math.floor(totalChannels / findDto.count) + 1;
+    page.totalPage = Math.floor(totalChannels / (findDto.count + 1)) + 1;
     page.currentPage =
       findDto.page > page.totalPage ? page.totalPage : findDto.page;
 

--- a/src/gateway/direct-message.gateway.ts
+++ b/src/gateway/direct-message.gateway.ts
@@ -89,7 +89,6 @@ export class DirectMessageGateway
           CHATTYPE_OTHERS,
         ),
       );
-    console.log('server', this.server);
     this.server
       ?.to(FriendChatManager.generateRoomId(userId, friendId))
       ?.except([...friend.dmSocket.keys()])
@@ -166,11 +165,7 @@ export class DirectMessageGateway
     this.userFactory.setDirectMessageFriendId(user.id, friend.id, socket.id);
     await socket.join(FriendChatManager.generateRoomId(user.id, friend.id));
 
-    try {
-      await this.updateLastMessageId(user.id, friend.id);
-    } catch (e) {
-      console.log('error in dear', e);
-    }
+    await this.updateLastMessageId(user.id, friend.id);
   }
 
   /**

--- a/src/gateway/notification.gateway.ts
+++ b/src/gateway/notification.gateway.ts
@@ -39,8 +39,7 @@ export class NotificationGateWay
   async handleConnection(@ConnectedSocket() socket: Socket): Promise<void> {
     const user: UserModel = await getUserFromSocket(socket, this.userFactory);
     if (!user) {
-      console.log('user not found', socket.id);
-      // socket.disconnect();
+      socket.disconnect();
       return;
     }
 

--- a/src/global/utils/socket.utils.ts
+++ b/src/global/utils/socket.utils.ts
@@ -28,7 +28,6 @@ export function getUserFromSocket(
 
   const accesstoken = socket.handshake.auth?.Authorization?.split(' ')[1];
   if (!accesstoken) {
-    console.log('no token', socket.id);
     return null;
   }
   try {
@@ -37,7 +36,6 @@ export function getUserFromSocket(
     const user: UserModel = userFactory.findById(userId);
     return user;
   } catch (e) {
-    console.log(accesstoken, e);
     return null;
   }
 }

--- a/src/test/data/channel.test.data.ts
+++ b/src/test/data/channel.test.data.ts
@@ -147,8 +147,8 @@ export class ChannelTestData {
     return this.channelFactory.findById(channel.id);
   }
 
-  async createBasicChannels(userNum: number): Promise<void> {
-    for (let i = 1; i < userNum; i++) {
+  async createBasicChannels(channelNum: number): Promise<void> {
+    for (let i = 1; i <= channelNum; i++) {
       await this.createBasicChannel('name' + i.toString(), i);
     }
   }

--- a/src/test/domain/channel/channel.normal.service.spec.ts
+++ b/src/test/domain/channel/channel.normal.service.spec.ts
@@ -160,10 +160,12 @@ describe('ChannelUserService', () => {
         expect(channelList.channels[0]).toHaveProperty('maxCount');
         expect(channelList).toHaveProperty('currentPage');
         expect(channelList).toHaveProperty('totalPage');
+        expect(channelList.currentPage).toBe(1);
+        expect(channelList.totalPage).toBe(1);
       });
 
       it('[Valid Case] 채팅방 목록 조회(popular)', async () => {
-        await channelData.createBasicChannels(10);
+        await channelData.createBasicChannels(12);
 
         const getPopularPageDto: GetChannelPageDto = {
           page: 1,
@@ -181,6 +183,8 @@ describe('ChannelUserService', () => {
         expect(channelList.channels[0]).toHaveProperty('maxCount');
         expect(channelList).toHaveProperty('currentPage');
         expect(channelList).toHaveProperty('totalPage');
+        expect(channelList.currentPage).toBe(1);
+        expect(channelList.totalPage).toBe(2);
         expect(channelList.channels[0].headCount).toBeGreaterThanOrEqual(
           channelList.channels[1].headCount,
         );


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#251 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 채널 목록 조회 시 totalPage가 잘못 반환되는 문제를 수정했습니다

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- ChannelRepository에서 totalPage를 계산할 때 페이지 당 개수 count와 채널 수가 나누어 떨어지면 page 숫자가 1 더해져서 나오는 문제를 수정했습니다
`page.totalPage = Math.floor(totalChannels / findDto.count) + 1;`
-> `page.totalPage = Math.floor(totalChannels / (findDto.count + 1)) + 1;`
- 불필요한 console log를 제거했습니다.
- 테스트코드에서 totalPage 조회를 제대로 하는지 테스트하는 부분을 추가했습니다